### PR TITLE
Implement slugged news URLs and Open Graph tags

### DIFF
--- a/src/modules/admin/components/noticias/NoticiaFormModal.jsx
+++ b/src/modules/admin/components/noticias/NoticiaFormModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { X, Upload, Calendar, User, FileType, Layers, Loader } from "lucide-react";
 import { obtenerCategorias } from "../../services";
+import { generateSlug } from "../../utils";
 
 export const NoticiaFormModal = ({
   isOpen,
@@ -174,7 +175,7 @@ export const NoticiaFormModal = ({
       return;
     }
 
-    const formData = { ...form };
+    const formData = { ...form, slug: generateSlug(form.titulo) };
     
     if (modo === "editar") {
       if (!formData.imagen_portada && initialData.imagen_portada_url) {

--- a/src/modules/admin/hooks/useNoticias.js
+++ b/src/modules/admin/hooks/useNoticias.js
@@ -32,12 +32,13 @@ export const useNoticias = () => {
     }
   }, []);
 
-  const obtenerDetalleCompleto = async (id) => {
-    const { data } = await obtenerDetalleNoticia(id);
+  const obtenerDetalleCompleto = async (slug) => {
+    const { data } = await obtenerDetalleNoticia(slug);
     const detalle = data[0];
-    
+
     return {
       id: detalle.id,
+      slug: detalle.slug,
       titulo: detalle.titulo,
       autor: detalle.autor,
       fecha_publicacion: formatearFecha(detalle.fecha_publicacion),
@@ -56,10 +57,11 @@ export const useNoticias = () => {
 
   const agregarNuevaNoticia = async (data) => {
     const response = await agregarNoticia(data);
-    const { id, imagenes } = response.data;
+    const { id, imagenes, slug } = response.data;
 
     const nuevaNoticia = {
       id,
+      slug: slug || data.slug,
       title: data.titulo,
       image: imagenes.imagen_portada,
       fechaPublicacion: data.fecha_publicacion,

--- a/src/modules/admin/pages/AdministradorNoticias.jsx
+++ b/src/modules/admin/pages/AdministradorNoticias.jsx
@@ -44,7 +44,7 @@ export const AdministradorNoticias = () => {
 
   const handleOpenEditForm = async (item) => {
     try {
-      const detalleNoticia = await obtenerDetalleCompleto(item.id);
+      const detalleNoticia = await obtenerDetalleCompleto(item.slug);
       setFormMode("editar");
       setSelectedItem(detalleNoticia);
       setFormModalOpen(true);

--- a/src/modules/admin/utils/formatters.js
+++ b/src/modules/admin/utils/formatters.js
@@ -1,6 +1,7 @@
 export const formatearListadoNoticias = (data) => {
   return data.map((noticia) => ({
     id: noticia.id,
+    slug: noticia.slug,
     title: noticia.titulo,
     image: noticia.imagen_portada,
     fechaPublicacion: noticia.fecha_publicacion,

--- a/src/modules/admin/utils/index.js
+++ b/src/modules/admin/utils/index.js
@@ -1,2 +1,3 @@
 export * from './fechaUtils';
 export * from './formatters';
+export * from './slugUtils';

--- a/src/modules/admin/utils/slugUtils.js
+++ b/src/modules/admin/utils/slugUtils.js
@@ -1,0 +1,10 @@
+export const generateSlug = (text) => {
+  return text
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+};

--- a/src/modules/config/noticiasGlobalService.js
+++ b/src/modules/config/noticiasGlobalService.js
@@ -5,8 +5,8 @@ export const obtenerNoticias = () => {
   return axios.get(`${API_BASE}/noticias/obtener-noticias`);
 };
 
-export const obtenerDetalleNoticia = (id) => {
-  return axios.get(`${API_BASE}/noticias/obtener-detalle-noticia/${id}`);
+export const obtenerDetalleNoticia = (slug) => {
+  return axios.get(`${API_BASE}/noticias/obtener-detalle-noticia/${slug}`);
 };
 
 export const obtenerCategorias = () => {

--- a/src/modules/home/hooks/useNewsData.js
+++ b/src/modules/home/hooks/useNewsData.js
@@ -51,16 +51,19 @@ export const useNewsData = () => {
         setNewsData({
           slide: principalNews.map((n) => ({
             id: n.id,
+            slug: n.slug,
             image: n.imagen_portada,
             title: n.titulo,
           })),
           secondNews: siguientes.map((n) => ({
             id: n.id,
+            slug: n.slug,
             image: n.imagen_portada,
             description: n.titulo,
           })),
           more: restantes.map((n) => ({
             id: n.id,
+            slug: n.slug,
             image: n.imagen_portada,
             description: n.titulo,
           })),

--- a/src/modules/home/hooks/useNewsDetails.js
+++ b/src/modules/home/hooks/useNewsDetails.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { obtenerDetalleNoticia, obtenerCategorias } from '../../config';
 
-export const useNewsDetails = (newsId) => {
+export const useNewsDetails = (slug) => {
   const [newsDetail, setNewsDetail] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -26,13 +26,13 @@ export const useNewsDetails = (newsId) => {
 
   useEffect(() => {
     const fetchNewsDetail = async () => {
-      if (!newsId) return;
+      if (!slug) return;
       
       try {
         setLoading(true);
         setError(null);
         
-        const { data } = await obtenerDetalleNoticia(newsId);
+        const { data } = await obtenerDetalleNoticia(slug);
         
         const arrayData = Array.isArray(data) ? data : [];
         
@@ -44,6 +44,7 @@ export const useNewsDetails = (newsId) => {
         
         const formattedNews = {
           id: n.id,
+          slug: n.slug,
           title: n.titulo,
           author: n.autor,
           date: new Date(n.fecha_publicacion).toLocaleDateString("es-MX", {
@@ -72,7 +73,7 @@ export const useNewsDetails = (newsId) => {
     if (Object.keys(categorias).length > 0 || loading) {
       fetchNewsDetail();
     }
-  }, [newsId, categorias]);
+  }, [slug, categorias]);
 
   return { newsDetail, loading, error };
 };

--- a/src/modules/home/hooks/useRelatedNews.js
+++ b/src/modules/home/hooks/useRelatedNews.js
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
 import { obtenerNoticias } from '../../config';
 
-export const useRelatedNews = (currentNewsId) => {
+export const useRelatedNews = (currentNewsSlug) => {
   const [relatedNews, setRelatedNews] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     const loadRelatedNews = async () => {
-      if (!currentNewsId) return;
+      if (!currentNewsSlug) return;
       
       try {
         setLoading(true);
@@ -18,13 +18,14 @@ export const useRelatedNews = (currentNewsId) => {
         const allNews = response.data;
         
         if (Array.isArray(allNews)) {
-          const filteredNews = allNews
-            .filter(news => news.id !== parseInt(currentNewsId))
-            .map(news => ({
-              id: news.id,
-              title: news.titulo,
-              image: news.imagen_portada,
-            }));
+        const filteredNews = allNews
+          .filter(news => news.slug !== currentNewsSlug)
+          .map(news => ({
+            id: news.id,
+            slug: news.slug,
+            title: news.titulo,
+            image: news.imagen_portada,
+          }));
           
           setRelatedNews(filteredNews);
         } else {
@@ -39,7 +40,7 @@ export const useRelatedNews = (currentNewsId) => {
     };
 
     loadRelatedNews();
-  }, [currentNewsId]);
+  }, [currentNewsSlug]);
 
   return { relatedNews, loading, error };
 };

--- a/src/modules/home/pages/DetailPage.jsx
+++ b/src/modules/home/pages/DetailPage.jsx
@@ -1,4 +1,5 @@
   import { useNavigate, useParams } from 'react-router';
+  import { useEffect } from 'react';
   import "@fortawesome/fontawesome-free/css/all.min.css";
   import logo from '../../../assets/logodos.png';
   import { useNewsDetails, useRelatedNews, useAdvertisement } from '../hooks';
@@ -6,17 +7,17 @@
 
   export const DetailPage = () => {
     const navigate = useNavigate();
-    const { id } = useParams();
-    const { newsDetail, loading, error } = useNewsDetails(id);
-    const { relatedNews } = useRelatedNews(id);
+    const { slug } = useParams();
+    const { newsDetail, loading, error } = useNewsDetails(slug);
+    const { relatedNews } = useRelatedNews(slug);
     const { banner } = useAdvertisement();
 
     const handleImageError = (e) => {
       e.target.src = 'https://via.placeholder.com/600x400?text=Imagen+no+disponible';
     };
 
-    const handleRelatedArticleClick = (articleId) => {
-      navigate(`/news/${articleId}`);
+    const handleRelatedArticleClick = (articleSlug) => {
+      navigate(`/news/${articleSlug}`);
     };
 
     if (loading) {
@@ -47,6 +48,34 @@
     instagram: "https://www.instagram.com/_plataformanews?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
     //youtube: "https://youtube.com/tupagina",
   };
+
+    useEffect(() => {
+      if (!newsDetail) return;
+
+      const metas = [
+        { property: 'og:title', content: newsDetail.title },
+        { property: 'og:description', content: newsDetail.content[0] || '' },
+        { property: 'og:image', content: newsDetail.images[0] },
+        { property: 'og:author', content: newsDetail.author },
+      ];
+
+      metas.forEach(({ property, content }) => {
+        let el = document.querySelector(`meta[property="${property}"]`);
+        if (!el) {
+          el = document.createElement('meta');
+          el.setAttribute('property', property);
+          document.head.appendChild(el);
+        }
+        el.setAttribute('content', content);
+      });
+
+      return () => {
+        metas.forEach(({ property }) => {
+          const el = document.querySelector(`meta[property="${property}"]`);
+          if (el) document.head.removeChild(el);
+        });
+      };
+    }, [newsDetail]);
 
     return (
       <>
@@ -102,7 +131,7 @@
                     <div 
                       key={index} 
                       className="flex gap-4 mb-5 items-center cursor-pointer hover:bg-gray-100 p-2 rounded-lg transition-colors"
-                      onClick={() => handleRelatedArticleClick(article.id)}
+                      onClick={() => handleRelatedArticleClick(article.slug)}
                     >
                       <div className="w-24 h-24 md:w-28 md:h-28 lg:w-32 lg:h-32 flex-shrink-0 rounded-md overflow-hidden relative">
                         <img 
@@ -125,7 +154,7 @@
                       <article 
                         key={`mobile-${index}`} 
                         className="flex-shrink-0 w-[250px] bg-black rounded-xl overflow-hidden relative h-[250px]"
-                        onClick={() => handleRelatedArticleClick(article.id)}
+                        onClick={() => handleRelatedArticleClick(article.slug)}
                       >
                         <img
                           className="w-full h-full object-cover rounded-xl hover:scale-110 transition-transform duration-300"

--- a/src/modules/home/pages/HomePage.jsx
+++ b/src/modules/home/pages/HomePage.jsx
@@ -9,8 +9,8 @@ export const HomePage = () => {
   const { banner } = useAdvertisement();
   const navigate = useNavigate();
 
-  const handleNewsClick = (id) => {
-    navigate(`/news/${id}`);
+  const handleNewsClick = (slug) => {
+    navigate(`/news/${slug}`);
   };
 
   const renderMainSection = () => {
@@ -31,7 +31,7 @@ export const HomePage = () => {
         <div className="lg:hidden w-full mb-8 h-[320px]">
           <MainNews
             slides={newsData.slide}
-            onNewsClick={(id) => handleNewsClick(id)}
+            onNewsClick={(slug) => handleNewsClick(slug)}
           />
         </div>
         
@@ -42,7 +42,7 @@ export const HomePage = () => {
                 key={news.id}
                 image={news.image}
                 description={news.description}
-                onClick={() => handleNewsClick(news.id)}
+                onClick={() => handleNewsClick(news.slug)}
               />
             ))}
           </div>
@@ -51,7 +51,7 @@ export const HomePage = () => {
             <div className="h-full flex">
               <MainNews
                 slides={newsData.slide}
-                onNewsClick={(id) => handleNewsClick(id)}
+                onNewsClick={(slug) => handleNewsClick(slug)}
               />
             </div>
           </div>
@@ -62,7 +62,7 @@ export const HomePage = () => {
                 key={news.id}
                 image={news.image}
                 description={news.description}
-                onClick={() => handleNewsClick(news.id)}
+                onClick={() => handleNewsClick(news.slug)}
               />
             ))}
           </div>
@@ -88,7 +88,7 @@ export const HomePage = () => {
                 key={news.id}
                 image={news.image}
                 description={news.description}
-                onClick={() => handleNewsClick(news.id)}
+                onClick={() => handleNewsClick(news.slug)}
               />
             ))}
           </div>

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -9,7 +9,7 @@ export const AppRouter = [
     element: <HomePage />,
   },
   {
-    path: "/news/:id",
+    path: "/news/:slug",
     element: <DetailPage />,
   },
   {


### PR DESCRIPTION
## Summary
- add utility to create SEO-friendly slugs
- include slug when creating or editing news
- adjust API services and hooks to use slug
- update router and navigation to use `/news/:slug`
- add Open Graph meta tags on news detail

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f8e286af08330ac1ebea2db39fae0